### PR TITLE
Update images to use Alpine 3.12

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.11.1-alpine3.8
+FROM golang:1.15.2-alpine3.12
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 
 MAINTAINER Frank Mai <frank@rancher.com>
 


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/29290

New image uses alpine:3.12 as seen from the excerpt of the `make` command below:
```bash
Sending build context to Docker daemon  30.18MB
Step 1/5 : FROM alpine:3.12
3.12: Pulling from library/alpine
Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
Status: Downloaded newer image for alpine:3.12
 ---> a24bb4013296
Step 2/5 : MAINTAINER Frank Mai <frank@rancher.com>
 ---> Running in c62cac7c30a8
Removing intermediate container c62cac7c30a8
 ---> 0113a3b19b05
Step 3/5 : RUN apk add --no-cache --update         curl openssl jq ca-certificates     ;     mkdir -p /data;     chown -R nobody:nogroup /data;     mkdir -p /run/cache
 ---> Running in f051175cdb14
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/7) Installing ca-certificates (20191127-r4)
(2/7) Installing nghttp2-libs (1.41.0-r0)
(3/7) Installing libcurl (7.69.1-r1)
(4/7) Installing curl (7.69.1-r1)
(5/7) Installing oniguruma (6.9.5-r1)
(6/7) Installing jq (1.6-r1)
(7/7) Installing openssl (1.1.1g-r0)
Executing busybox-1.31.1-r16.trigger
Executing ca-certificates-20191127-r4.trigger
OK: 9 MiB in 21 packages
Removing intermediate container f051175cdb14
 ---> 3c8e36ea3625
Step 4/5 : COPY prometheus-auth /usr/bin/
 ---> c90f5e16fc53
Step 5/5 : ENTRYPOINT ["/usr/bin/prometheus-auth"]
 ---> Running in 856b49a4a999
Removing intermediate container 856b49a4a999
 ---> 738074f172f7
Successfully built 738074f172f7
Successfully tagged rancher/prometheus-auth:dev
Built rancher/prometheus-auth:dev
```