### PR TITLE
use jwt token claim to validate serviceaccount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 require (
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/cockroachdb/cockroach v0.0.0-20170608034007-84bc9597164f
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=

--- a/pkg/kube/namespaces.go
+++ b/pkg/kube/namespaces.go
@@ -90,6 +90,9 @@ func (n *namespaces) validate(token string) (string, error) {
 	// bound token
 	case "rke":
 		claimNamespace = claims["kubernetes.io"].(map[string]interface{})["namespace"].(string)
+	// k3s
+	case "https://kubernetes.default.svc.cluster.local":
+		claimNamespace = claims["kubernetes.io"].(map[string]interface{})["namespace"].(string)
 	// legacy token
 	case "kubernetes/serviceaccount":
 		claimNamespace = claims["kubernetes.io/serviceaccount/namespace"].(string)


### PR DESCRIPTION
Starting from Kubernetes 1.21 Bound Service Account token becomes default and within there are differences between the token stored in the secret and in-placed token in the POD. A [simple string compare of the encoded token](https://github.com/rancher/prometheus-auth/blob/master/pkg/kube/namespaces.go#L83) won't work anymore.
Instead all information are available in JWT claim and this PR used this to find out the project monitoring namespace.
Legacy and bound tokens are supported.

ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens